### PR TITLE
Fix: prevent the map of secrets to be cleared by the cache refresh while retrieving a secret value 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-core-test</artifactId>
+      <version>1.5.0</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- provided scope to exclude packages having NexusIQ violations -->
     <dependency>
       <groupId>org.simpleframework</groupId>

--- a/src/main/java/com/abnamro/microsoft/azure/microprofile/config/keyvault/AzureKeyVaultOperation.java
+++ b/src/main/java/com/abnamro/microsoft/azure/microprofile/config/keyvault/AzureKeyVaultOperation.java
@@ -76,11 +76,17 @@ class AzureKeyVaultOperation {
   String getValue(String secretName) {
     checkRefreshTimeOut();
 
-    if (knownSecretKeys.contains(secretName)) {
-      return propertiesMap
-          .computeIfAbsent(secretName,
-              key -> secretKeyVaultClient.getSecret(secretName).getValue());
+    try {
+      rwLock.readLock().lock();
+      if (knownSecretKeys.contains(secretName)) {
+        return propertiesMap
+                .computeIfAbsent(secretName,
+                        key -> secretKeyVaultClient.getSecret(secretName).getValue());
+      }
+    } finally {
+      rwLock.readLock().unlock();
     }
+
 
     return null;
   }

--- a/src/main/java/com/abnamro/microsoft/azure/microprofile/config/keyvault/AzureKeyVaultOperation.java
+++ b/src/main/java/com/abnamro/microsoft/azure/microprofile/config/keyvault/AzureKeyVaultOperation.java
@@ -1,9 +1,10 @@
 package com.abnamro.microsoft.azure.microprofile.config.keyvault;
 
-import com.azure.identity.ManagedIdentityCredentialBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.security.keyvault.secrets.SecretClient;
 import com.azure.security.keyvault.secrets.SecretClientBuilder;
 import com.azure.security.keyvault.secrets.models.SecretProperties;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 import java.util.Collections;
 import java.util.Map;
@@ -13,12 +14,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import org.eclipse.microprofile.config.ConfigProvider;
 
 
 class AzureKeyVaultOperation {
 
-  private static final long CACHE_REFRESH_INTERVAL_IN_MS = 1800000L; // 30 minutes
+  private static final long DEFAULT_CACHE_REFRESH_INTERVAL_IN_MS = 1800000L; // 30 minutes
+
+  private final long cacheRefreshIntervalInMs; // 30 minutes
 
   private final SecretClient secretKeyVaultClient;
 
@@ -29,9 +31,24 @@ class AzureKeyVaultOperation {
   private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
 
   AzureKeyVaultOperation() {
-    String keyVaultURL = ConfigProvider.getConfig().getValue("azure.keyvault.url", String.class);
-    this.secretKeyVaultClient = new SecretClientBuilder().vaultUrl(keyVaultURL)
-        .credential(new ManagedIdentityCredentialBuilder().build()).buildClient();
+    this(DEFAULT_CACHE_REFRESH_INTERVAL_IN_MS);
+  }
+  AzureKeyVaultOperation(long cacheRefreshIntervalInMs) {
+    this(cacheRefreshIntervalInMs, defaultSecretKeyVaultClient());
+  }
+
+  AzureKeyVaultOperation(long cacheRefreshIntervalInMs, SecretClient secretKeyVaultClient) {
+    this.cacheRefreshIntervalInMs = cacheRefreshIntervalInMs;
+    this.secretKeyVaultClient = secretKeyVaultClient;
+  }
+
+  private static SecretClient defaultSecretKeyVaultClient() {
+    return new SecretClientBuilder().vaultUrl(getKeyVaultUrlFromConfig())
+            .credential(new DefaultAzureCredentialBuilder().build()).buildClient();
+  }
+
+  private static String getKeyVaultUrlFromConfig() {
+    return ConfigProvider.getConfig().getValue("azure.keyvault.url", String.class);
   }
 
   Set<String> getKeys() {
@@ -70,7 +87,7 @@ class AzureKeyVaultOperation {
 
   private void checkRefreshTimeOut() {
     // refresh periodically
-    if (System.currentTimeMillis() - lastUpdateTime.get() > CACHE_REFRESH_INTERVAL_IN_MS) {
+    if (System.currentTimeMillis() - lastUpdateTime.get() > cacheRefreshIntervalInMs) {
       lastUpdateTime.set(System.currentTimeMillis());
       createOrUpdateHashMap();
     }

--- a/src/test/java/com/abnamro/microsoft/azure/microprofile/config/keyvault/AzureKeyVaultOperationTest.java
+++ b/src/test/java/com/abnamro/microsoft/azure/microprofile/config/keyvault/AzureKeyVaultOperationTest.java
@@ -1,0 +1,55 @@
+package com.abnamro.microsoft.azure.microprofile.config.keyvault;
+
+import com.abnamro.microsoft.azure.microprofile.config.keyvault.util.MockAzureKeyVaultClient;
+import com.azure.core.http.HttpClient;
+import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AzureKeyVaultOperationTest {
+
+    @Mock
+    private HttpClient httpClient;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+    @Test
+    void getSameValue() {
+        AzureKeyVaultOperation azureKeyVaultOperation = new AzureKeyVaultOperation(0L, MockAzureKeyVaultClient.simpleSecretClientMock(httpClient));
+        KeyVaultSecret keyVaultSecret1 = new KeyVaultSecret("secret1","value1");
+        List<KeyVaultSecret> keyVaultSecrets = Arrays.asList(keyVaultSecret1);
+
+        MockAzureKeyVaultClient.simpleAzureKeyvaultMock(keyVaultSecrets, httpClient);
+
+        azureKeyVaultOperation.getValue("secret1");
+
+        IntStream.range(1, 5).mapToObj(x -> "secret1")
+                .map(azureKeyVaultOperation::getValue)
+                .forEach(value -> assertEquals("value1", value));
+    }
+
+    @Test
+    void getSameValueInParallel() {
+        AzureKeyVaultOperation azureKeyVaultOperation = new AzureKeyVaultOperation(0L, MockAzureKeyVaultClient.simpleSecretClientMock(httpClient));
+        KeyVaultSecret keyVaultSecret1 = new KeyVaultSecret("secret1","value1");
+        List<KeyVaultSecret> keyVaultSecrets = Arrays.asList(keyVaultSecret1);
+
+        MockAzureKeyVaultClient.simpleAzureKeyvaultMock(keyVaultSecrets, httpClient);
+
+        azureKeyVaultOperation.getValue("secret1");
+
+        IntStream.range(1, 5).mapToObj(x -> "secret1").parallel()
+                .map(azureKeyVaultOperation::getValue)
+                .forEach(value -> assertEquals("value1", value));
+    }
+}

--- a/src/test/java/com/abnamro/microsoft/azure/microprofile/config/keyvault/util/MockAzureKeyVaultClient.java
+++ b/src/test/java/com/abnamro/microsoft/azure/microprofile/config/keyvault/util/MockAzureKeyVaultClient.java
@@ -1,0 +1,91 @@
+package com.abnamro.microsoft.azure.microprofile.config.keyvault.util;
+
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.HttpPipeline;
+import com.azure.core.http.HttpPipelineBuilder;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.Page;
+import com.azure.core.test.http.MockHttpResponse;
+import com.azure.core.util.IterableStream;
+import com.azure.security.keyvault.secrets.SecretClient;
+import com.azure.security.keyvault.secrets.SecretClientBuilder;
+import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
+import com.azure.security.keyvault.secrets.models.SecretProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jetbrains.annotations.NotNull;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+public class MockAzureKeyVaultClient {
+
+    public static final int STATUS_CODE_OK = 200;
+
+    private MockAzureKeyVaultClient() {}
+
+    public static HttpClient simpleAzureKeyvaultMock(Collection<KeyVaultSecret> keyVaultSecrets) {
+        return simpleAzureKeyvaultMock(keyVaultSecrets, Mockito.mock(HttpClient.class));
+    }
+
+    public static SecretClient simpleSecretClientMock(HttpClient httpClient) {
+        HttpPipeline mockPipeline = new HttpPipelineBuilder().httpClient(httpClient).build();
+        return new SecretClientBuilder()
+                .pipeline(mockPipeline).vaultUrl("https://localhost")
+                .buildClient();
+    }
+
+    public static HttpClient simpleAzureKeyvaultMock(Collection<KeyVaultSecret> keyVaultSecrets, HttpClient httpClient) {
+        mockHttpClientResponse(keyVaultSecrets, httpClient);
+        return httpClient;
+    }
+
+    private static <T> void mockHttpClientResponse(Collection<KeyVaultSecret> keyVaultSecrets, HttpClient httpClient) {
+
+        Map<String, Object> urlToResponseMap = urlToResponseMapFromSecrets(keyVaultSecrets);
+        when(httpClient.send(any())).thenAnswer(invocationOnMock -> {
+            String url = invocationOnMock.getArgumentAt(0, HttpRequest.class).getUrl().getPath();
+            byte[] serialized = new ObjectMapper().writer().writeValueAsBytes(urlToResponseMap.get(url));
+            HttpRequest request = invocationOnMock.getArgumentAt(0, HttpRequest.class);
+            return Mono.just(new MockHttpResponse(request, STATUS_CODE_OK, serialized));
+        });
+    }
+
+    @NotNull
+    private static Map<String, Object> urlToResponseMapFromSecrets(Collection<KeyVaultSecret> keyVaultSecrets) {
+        SecretPropertiesPageMock secretPropertiesPageMock = new SecretPropertiesPageMock();
+        secretPropertiesPageMock.items = keyVaultSecrets.stream()
+                .map(KeyVaultSecret::getProperties)
+                .collect(Collectors.toList());
+        Map<String, Object> objectMap = new HashMap<>();
+        objectMap.put("/secrets", secretPropertiesPageMock);
+        keyVaultSecrets.forEach(secret -> objectMap.put(String.format("/secrets/%s/", secret.getName()),secret));
+        return objectMap;
+    }
+
+    public static final class SecretPropertiesPageMock implements Page<SecretProperties> {
+        @JsonProperty("nextLink")
+        public String continuationToken;
+        @JsonProperty("value")
+        public List<SecretProperties> items;
+
+        public SecretPropertiesPageMock() {
+        }
+
+        public String getContinuationToken() {
+            return this.continuationToken;
+        }
+
+        public IterableStream<SecretProperties> getElements() {
+            return IterableStream.of(this.items);
+        }
+    }
+}


### PR DESCRIPTION
- Additional constructor for AzureKeyVaultOperation added for facilitating unit tests
- Added some unit tests AzureKeyVaultOperation
- Lock (write) access to secret map when reading accessing a value to prevent the map to be cleared by the cache refresh operation while accessing it